### PR TITLE
Introduce table_get_unchecked() to avoid non-standard syntax in table_get()

### DIFF
--- a/src/table.c
+++ b/src/table.c
@@ -2,6 +2,15 @@
 #include "object.h"
 #include "util.h"
 
+void *access_if_idx_not_null(void *array, size_t itemsize, int *i)
+{
+  if (i == NULL) {
+    return NULL;
+  }
+
+  return (char*)array + (*i)*itemsize;
+}
+
 int *list_find(Bucket *head, const char *item) {
   while (head != NULL) {
     if (strcmp(head->key, item) == 0)

--- a/src/vm.c
+++ b/src/vm.c
@@ -108,8 +108,8 @@ static inline bool check_equality(Object *left, Object *right) {
       if (a->properties.indexes[i] == NULL)
         continue;
       char *key = a->properties.indexes[i]->key;
-      if (!check_equality(table_get(&a->properties, key),
-                          table_get(&b->properties, key))) {
+      if (!check_equality(table_get_unchecked(&a->properties, key),
+                          table_get_unchecked(&b->properties, key))) {
         return false;
       }
     }
@@ -300,7 +300,7 @@ static inline int handle_op_get_global(VM *vm, BytecodeChunk *chunk,
    * nce the object will be present in yet another location,
    * the refcount must be incremented. */
   uint32_t name_idx = READ_UINT32();
-  Object *obj = table_get(&vm->globals, chunk->sp.data[name_idx]);
+  Object *obj = table_get_unchecked(&vm->globals, chunk->sp.data[name_idx]);
   push(vm, *obj);
   OBJECT_INCREF(*obj);
   return 0;
@@ -313,7 +313,7 @@ static inline int handle_op_get_global_ptr(VM *vm, BytecodeChunk *chunk,
    * name in in the vm's globals table, and pushes its add-
    * ress on the stack. */
   uint32_t name_idx = READ_UINT32();
-  Object *obj = table_get(&vm->globals, chunk->sp.data[name_idx]);
+  Object *obj = table_get_unchecked(&vm->globals, chunk->sp.data[name_idx]);
   push(vm, AS_PTR(obj));
   return 0;
 }


### PR DESCRIPTION
The old `table_get()` macro returned a pointer of the correct type, or NULL if not found, but uses non-standard syntax to do this. I believe the non-standard syntax is GNU specific.

This PR changes `table_get()` to return a `void*`, which isn't great, but as far as I can tell, it is the best we can do if we want to:
- stick to standard syntax
- not search the table twice when one search would be enough
- keep usages of `table_get()` as simple as they are now.

I also added a new macro `table_get_unchecked()` that doesn't check for "not found" cases. Because of this, it can simply return a pointer of the correct type without using non-standard syntax.